### PR TITLE
Fix environment variable precedence bug

### DIFF
--- a/fill_environments.go
+++ b/fill_environments.go
@@ -15,9 +15,9 @@ func FillEnvironments(c interface{}) (err error) {
 
 	traverse(c, func(i item) {
 		env := strings.ToUpper(strings.Join(i.Path, "_"))
-		value := os.Getenv(env)
+		value, ok := os.LookupEnv(env)
 
-		if "" == value {
+		if !ok {
 			return
 		}
 

--- a/fill_environments_test.go
+++ b/fill_environments_test.go
@@ -140,3 +140,16 @@ func TestFillEnvironmentsWithArrayMalformed(t *testing.T) {
 		" array: invalid character '}' looking for beginning of value")
 
 }
+
+func TestFillEnvironmentsEmptyOverride(t *testing.T) {
+	c := struct {
+		Value string
+	}{Value: "default"}
+
+	os.Setenv("VALUE", "")
+
+	err := FillEnvironments(&c)
+	AssertNil(t, err)
+
+	AssertEqual(t, c.Value, "")
+}

--- a/fill_json.go
+++ b/fill_json.go
@@ -58,7 +58,12 @@ func unmarshalJSON(data []byte, c interface{}) error {
 				return
 			}
 
-			if reflect.TypeOf(i.Value.Type()).Implements(reflect.TypeOf(new(json.Unmarshaler)).Elem()) {
+			unmarshaler := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+
+			if reflect.PtrTo(i.Value.Type()).Implements(unmarshaler) {
+				json.Unmarshal(value, i.Ptr)
+
+			} else if i.Value.Kind() == reflect.Struct {
 				unmarshalJSON(value, i.Ptr)
 
 			} else if reflect.TypeOf(time.Duration(0)) == i.Value.Type() {

--- a/new_test.go
+++ b/new_test.go
@@ -1,0 +1,28 @@
+package goconfig
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func TestFillJsonNestedDuration(t *testing.T) {
+	f, err := ioutil.TempFile("", "test-nested-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(`{"Server":{"Timeout":"10s"}}`); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := struct {
+		Server struct{ Timeout time.Duration }
+	}{}
+
+	err = FillJson(&cfg, f.Name())
+	AssertNil(t, err)
+	if cfg.Server.Timeout != 10*time.Second {
+		t.Errorf("expected 10s, got %s", cfg.Server.Timeout)
+	}
+}


### PR DESCRIPTION
## Summary
- fix environment variable parsing when empty strings are set
- add regression test ensuring empty values override defaults
- fix JSON nested struct parsing
- add regression test for nested duration values

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6886c0519ce4832b906231716015b408