### PR TITLE
Show env vars in help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,23 +66,23 @@ Running your program with `-help` prints automatically generated help text:
 ```
 Usage of example:
   -enablelog
-        Enable logging into logdb (default true)
+        Enable logging into logdb (env ENABLELOG) (default true)
   -logdb.host string
-        Host where db is located (default "localhost")
+        Host where db is located (env LOGDB_HOST) (default "localhost")
   -logdb.pass string
-        Database password (default "123456")
+        Database password (env LOGDB_PASS) (default "123456")
   -logdb.user string
-        Database user (default "root")
+        Database user (env LOGDB_USER) (default "root")
   -maxprocs int
-        Maximum number of procs
+        Maximum number of procs (env MAXPROCS)
   -name string
-        The name of something
+        The name of something (env NAME)
   -usersdb.host string
-        Host where db is located
+        Host where db is located (env USERSDB_HOST)
   -usersdb.pass string
-        Database password
+        Database password (env USERSDB_PASS)
   -usersdb.user string
-        Database user
+        Database user (env USERSDB_USER)
 ```
 
 ## Supported Types

--- a/fill_args.go
+++ b/fill_args.go
@@ -31,10 +31,17 @@ func FillArgs(c interface{}, args []string) error {
 
 	traverse(c, func(i item) {
 		name_path := strings.ToLower(strings.Join(i.Path, "."))
+		env_name := strings.ToUpper(strings.Join(i.Path, "_"))
+
+		usage := i.Usage
+		if usage != "" {
+			usage += " "
+		}
+		usage += "(env " + env_name + ")"
 
 		if reflect.TypeOf(time.Duration(0)) == i.Value.Type() {
 			value := ""
-			f.StringVar(&value, name_path, i.Value.Interface().(time.Duration).String(), i.Usage)
+			f.StringVar(&value, name_path, i.Value.Interface().(time.Duration).String(), usage)
 
 			post = append(post, postFillArgs{
 				Raw:  &value,
@@ -42,32 +49,32 @@ func FillArgs(c interface{}, args []string) error {
 			})
 
 		} else if reflect.Bool == i.Kind {
-			f.BoolVar(i.Ptr.(*bool), name_path, i.Value.Interface().(bool), i.Usage)
+			f.BoolVar(i.Ptr.(*bool), name_path, i.Value.Interface().(bool), usage)
 
 		} else if reflect.Float64 == i.Kind {
-			f.Float64Var(i.Ptr.(*float64), name_path, i.Value.Interface().(float64), i.Usage)
+			f.Float64Var(i.Ptr.(*float64), name_path, i.Value.Interface().(float64), usage)
 
 		} else if reflect.Int64 == i.Kind {
-			f.Int64Var(i.Ptr.(*int64), name_path, i.Value.Interface().(int64), i.Usage)
+			f.Int64Var(i.Ptr.(*int64), name_path, i.Value.Interface().(int64), usage)
 
 		} else if reflect.Int == i.Kind {
-			f.IntVar(i.Ptr.(*int), name_path, i.Value.Interface().(int), i.Usage)
+			f.IntVar(i.Ptr.(*int), name_path, i.Value.Interface().(int), usage)
 
 		} else if reflect.String == i.Kind {
-			f.StringVar(i.Ptr.(*string), name_path, i.Value.Interface().(string), i.Usage)
+			f.StringVar(i.Ptr.(*string), name_path, i.Value.Interface().(string), usage)
 
 		} else if reflect.Uint64 == i.Kind {
-			f.Uint64Var(i.Ptr.(*uint64), name_path, i.Value.Interface().(uint64), i.Usage)
+			f.Uint64Var(i.Ptr.(*uint64), name_path, i.Value.Interface().(uint64), usage)
 
 		} else if reflect.Uint == i.Kind {
-			f.UintVar(i.Ptr.(*uint), name_path, i.Value.Interface().(uint), i.Usage)
+			f.UintVar(i.Ptr.(*uint), name_path, i.Value.Interface().(uint), usage)
 
 		} else if reflect.Slice == i.Kind {
 
 			b, _ := json.Marshal(i.Value.Interface())
 
 			value := ""
-			f.StringVar(&value, name_path, string(b), i.Usage)
+			f.StringVar(&value, name_path, string(b), usage)
 
 			post = append(post, postFillArgs{
 				Raw:  &value,

--- a/fill_args_test.go
+++ b/fill_args_test.go
@@ -1,6 +1,7 @@
 package goconfig
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -231,5 +232,26 @@ func TestFillArgsParseFail(t *testing.T) {
 
 	err := FillArgs(&c, args)
 	AssertNotNil(t, err)
+
+}
+
+func TestFillArgsHelpEnvNames(t *testing.T) {
+
+	c := struct {
+		UsersDB struct {
+			Host string `usage:"Host where Database is located"`
+			Pass string `usage:"Database password"`
+		}
+	}{}
+
+	args := []string{"-help"}
+
+	err := FillArgs(&c, args)
+	AssertNotNil(t, err)
+
+	s := err.Error()
+	if !strings.Contains(s, "USERSDB_HOST") || !strings.Contains(s, "USERSDB_PASS") {
+		t.Errorf("help output should contain environment variables: %s", s)
+	}
 
 }


### PR DESCRIPTION
## Summary
- include env variable names in auto-generated CLI help
- test that help output shows env variable names
- update README help example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6886e04272d4832ba61633a114815cb7